### PR TITLE
References are strong by default

### DIFF
--- a/strongself.m
+++ b/strongself.m
@@ -4,4 +4,4 @@ summary: "Declare strong reference to weak reference"
 completion-scope: Function or Method
 ---
 
-__strong __typeof(<#weakSelf#>)strongSelf = <#weakSelf#>;
+__typeof(<#weakSelf#>)strongSelf = <#weakSelf#>;


### PR DESCRIPTION
We do not need to mention `__strong` since it is by default.