### PR TITLE
fix: crash on xcode8; add Installing All Snippets to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,20 @@ Just a few code snippets I have in my Xcode arsenal. In [dotfiles](http://dotfil
 In Xcode 4, open a workspace and toggle the right sidebar to be visible. On the bottom, there is a panel with four icons in the header. Click on the `{ }` icon to open the Code Snippets Library.
 
 Now copy-paste the code from one of these snippets, highlight the code block you just pasted and drag it to the Code Snippet panel. Make sure to match the suggested platform, language, and completion scope. The completion shortcut corresponds to the filename of the code snippet.
+
+## Installing All Snippets
+
+To get started, install the xcodesnippet gem.
+
+```
+$ gem install xcodesnippet
+```
+
+Once installed, navigate to the directory where the snippets repository has been cloned and run
+
+```
+for f in *.m; do xcodesnippet install $f;  done
+```
+
+This will batch process all of the snippets available in the repository and add them to Xcode.
+

--- a/cdfetch.m
+++ b/cdfetch.m
@@ -1,7 +1,7 @@
 ---
 title: "Core Data Fetch"
 summary: "Simple Core Data Fetch with Predicate & Sort Descriptor"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:<#entityName#>];

--- a/checkerror.m
+++ b/checkerror.m
@@ -4,7 +4,7 @@ summary: "Function that extracts human-readable information from OSStatus codes.
 credit: "'Learning Core Audio: A Hands-on Guide to Audio Programming for Mac and iOS', by Chris Adamson, Kevin Avila"
 completion-scopes:
   - Code Expression
-  - Function or Method
+  - CodeBlock
 ---
 
 static void CheckError(OSStatus error, const char *operation) {

--- a/continuation.m
+++ b/continuation.m
@@ -1,7 +1,7 @@
 ---
 title: "Class Continuation"
 summary: "Anonymous category to define private methods in an implementation"
-completion-scope: Top Level
+completion-scope: TopLevel
 ---
 
 @interface <#Class Name#> ()

--- a/cvds.m
+++ b/cvds.m
@@ -2,7 +2,7 @@
 title: "UICollectionViewDataSource"
 summary: "Placeholders for essential UICollectionViewDataSource delegate methods"
 platform: iOS
-completion-scope: Class Implementation
+completion-scope: ClassImplementation
 ---
 
 #pragma mark - UICollectionViewDataSource

--- a/documents.m
+++ b/documents.m
@@ -1,6 +1,6 @@
 ---
 title: "Documents Directory Path"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 NSURL *documentsDirectoryURL = [NSURL fileURLWithPath:[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject]];

--- a/frame.m
+++ b/frame.m
@@ -1,7 +1,7 @@
 ---
 title: "Set Frame"
 summary: "Initializes a view frame inside a code block"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 <# view #>.frame = ({

--- a/frc.m
+++ b/frc.m
@@ -2,7 +2,7 @@
 title: "NSFetchedResultsController"
 summary: "Boilerplate for creating an NSFetchedResultsController"
 platform: iOS
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:<#(NSString *)#>];

--- a/frcd.m
+++ b/frcd.m
@@ -2,7 +2,7 @@
 title: "NSFetchedResultsControllerDelegate"
 summary: "Placeholders for the fetched results controller delegate methods"
 platform: iOS
-completion-scope: Class Implementation
+completion-scope: ClassImplementation
 ---
 
 #pragma mark - NSFetchedResultsControllerDelegate

--- a/imv.m
+++ b/imv.m
@@ -2,7 +2,7 @@
 title: "ImageView"
 summary: "Create & Initialize UIImageView with Named Image"
 platform: iOS
-completion-scope: Code Expression
+completion-scope: CodeExpression
 ---
 
 [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"<#image name#>"]]

--- a/init.m
+++ b/init.m
@@ -1,7 +1,7 @@
 ---
 title: "init"
 summary: "Designated incantation for your designated initializers"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 self = [super init];

--- a/library.m
+++ b/library.m
@@ -1,6 +1,6 @@
 ---
 title: "Library Directory Path"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) firstObject];

--- a/lifecycle.m
+++ b/lifecycle.m
@@ -2,7 +2,7 @@
 title: "UIViewController Lifecycle"
 summary: "Placeholders for all of the view controller lifecycle methods"
 platform: iOS
-completion-scope: Class Implementation
+completion-scope: ClassImplementation
 ---
 
 #pragma mark - UIViewController

--- a/mailcomp.m
+++ b/mailcomp.m
@@ -2,7 +2,7 @@
 title: "MFMailComposeViewController Initialization & Delegate"
 summary: "Methods required to use the iOS Mail Composer"
 platform: iOS
-completion-scope: Class Implementation
+completion-scope: ClassImplementation
 ---
 
 #import <MessageUI/MessageUI.h>

--- a/mark.m
+++ b/mark.m
@@ -2,9 +2,9 @@
 title: "#pragma Mark"
 summary: "Dividers and labels to organize your code into sections"
 completion-scopes:
-  - Top Level
-  - Class Implementation
-  - Class Interface Methods
+  - TopLevel
+  - ClassImplementation
+  - ClassInterfaceMethods
 ---
 
 #pragma mark - <#Section#>

--- a/nscoding.m
+++ b/nscoding.m
@@ -1,7 +1,7 @@
 ---
 title: "NSCoding Protocol Methods"
 summary: "Placeholders for NSCoding protocol methods"
-completion-scope: Class Implementation
+completion-scope: ClassImplementation
 ---
 
 #pragma mark - NSCoding

--- a/nsl.m
+++ b/nsl.m
@@ -1,6 +1,6 @@
 ---
 title: "NSLocalizedString"
-completion-scope: Code Expression
+completion-scope: CodeExpression
 ---
 
 NSLocalizedString(@"<#Message#>", <#Comment#>)

--- a/pdel.m
+++ b/pdel.m
@@ -2,7 +2,7 @@
 title: "UIPickerViewDelegate"
 summary: "Placeholders for required UIPickerView Delegate methods"
 platform: iOS
-completion-scope: Class Implementation
+completion-scope: ClassImplementation
 ---
 
 #pragma mark - UIPickerViewDelegate

--- a/pds.m
+++ b/pds.m
@@ -2,7 +2,7 @@
 title: "UIPickerViewDataSource"
 summary: "Placeholders for required UIPickerView datasource methods"
 platform: iOS
-completion-scope: Class Implementation
+completion-scope: ClassImplementation
 ---
 
 #pragma mark - UIPickerDataSource

--- a/singleton.m
+++ b/singleton.m
@@ -1,7 +1,7 @@
 ---
 title: "Shared Singleton"
 summary: "Class method that returns a singleton instance"
-completion-scope: Class Implementation
+completion-scope: ClassImplementation
 ---
 
 + (instancetype)shared<#name#> {

--- a/stack.m
+++ b/stack.m
@@ -1,6 +1,6 @@
 ---
 title: "Log Stack Trace"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 NSLog(@"Call Stack: %@", [NSThread callStackSymbols]);

--- a/strongself.m
+++ b/strongself.m
@@ -1,7 +1,7 @@
 ---
 title: "__strong self"
 summary: "Declare strong reference to weak reference"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 __strong __typeof(<#weakSelf#>)strongSelf = <#weakSelf#>;

--- a/tu.m
+++ b/tu.m
@@ -1,7 +1,7 @@
 ---
 title: "UIControlEventTouchUpInside"
 platform: iOS
-completion-scope: Code Expression
+completion-scope: CodeExpression
 ---
 
 UIControlEventTouchUpInside

--- a/tvdel.m
+++ b/tvdel.m
@@ -2,7 +2,7 @@
 title: "UITableViewDelegate"
 summary: "Placeholders for required UITableViewDelegate protocol methods"
 platform: iOS
-completion-scope: Class Implementation
+completion-scope: ClassImplementation
 ---
 
 #pragma mark - UITableViewDelegate

--- a/tvds.m
+++ b/tvds.m
@@ -2,7 +2,7 @@
 title: "UITableViewDataSource"
 summary: "Placeholders for required UITableViewDataSource delegate methods"
 platform: iOS
-completion-scope: Class Implementation
+completion-scope: ClassImplementation
 ---
 
 #pragma mark - UITableViewDataSource

--- a/weakself.m
+++ b/weakself.m
@@ -1,7 +1,7 @@
 ---
 title: "__weak self"
 summary: "Declare weak reference to self"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 __weak typeof(self)weakSelf = self;

--- a/xae.m
+++ b/xae.m
@@ -1,7 +1,7 @@
 ---
 title: "XCT Assert Equals"
 summary: "Assert equals for XCTest"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 XCTAssertEqual(<#expected#>, <#actual#>, <#message#>);

--- a/xaf.m
+++ b/xaf.m
@@ -1,7 +1,7 @@
 ---
 title: "XCT Assert False"
 summary: "Assert false for XCTest"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 XCTAssertFalse(<#expression#>, <#message#>);

--- a/xan.m
+++ b/xan.m
@@ -1,7 +1,7 @@
 ---
 title: "XCT Assert Nil"
 summary: "Assert for XCTest"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 XCTAssertNil(<#expression#>, <#message#>);

--- a/xann.m
+++ b/xann.m
@@ -1,7 +1,7 @@
 ---
 title: "XCT Assert Not Nil"
 summary: "Assert not nil for XCTest"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 XCTAssertNotNil(<#expression#>, <#message#>);

--- a/xat.m
+++ b/xat.m
@@ -1,7 +1,7 @@
 ---
 title: "XCT Assert True"
 summary: "Assert true for XCTest"
-completion-scope: Function or Method
+completion-scope: CodeBlock
 ---
 
 XCTAssertTrue(<#expression#>, <#message#>);


### PR DESCRIPTION
codesnippet file format was changed in Xcode8.  

Install old codesnippet files in xcode 8 will make xcode crash.

all these snippets files should be changed.

BTW:  ruby gem xcodesnippet should be updated to.